### PR TITLE
feat(cache): add admin-protected proxy cache invalidation endpoint

### DIFF
--- a/doc/insomnia/internal-api-keys.insomnia.json
+++ b/doc/insomnia/internal-api-keys.insomnia.json
@@ -29,6 +29,12 @@
       "name": "internal/api-keys"
     },
     {
+      "_id": "fld_internal_cache",
+      "_type": "request_group",
+      "parentId": "wrk_bb_bus_server_internal_api_keys",
+      "name": "internal/cache"
+    },
+    {
       "_id": "req_create_api_key",
       "_type": "request",
       "parentId": "fld_internal_api_keys",
@@ -97,6 +103,94 @@
         "type": "bearer",
         "token": "{{ _.admin_bearer_token }}"
       }
+    },
+    {
+      "_id": "req_cache_invalidate_exact",
+      "_type": "request",
+      "parentId": "fld_internal_cache",
+      "name": "Invalidate Cache (exact)",
+      "method": "POST",
+      "url": "{{ _.base_url }}/internal/cache/invalidate",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n  \"scope\": \"exact\",\n  \"path\": \"/pst/find?areaId=10790\"\n}"
+      },
+      "authentication": {
+        "type": "bearer",
+        "token": "{{ _.admin_bearer_token }}"
+      },
+      "headers": [
+        {
+          "name": "Content-Type",
+          "value": "application/json"
+        }
+      ]
+    },
+    {
+      "_id": "req_cache_invalidate_prefix",
+      "_type": "request",
+      "parentId": "fld_internal_cache",
+      "name": "Invalidate Cache (prefix)",
+      "method": "POST",
+      "url": "{{ _.base_url }}/internal/cache/invalidate",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n  \"scope\": \"prefix\",\n  \"pathPrefix\": \"/pst/find\"\n}"
+      },
+      "authentication": {
+        "type": "bearer",
+        "token": "{{ _.admin_bearer_token }}"
+      },
+      "headers": [
+        {
+          "name": "Content-Type",
+          "value": "application/json"
+        }
+      ]
+    },
+    {
+      "_id": "req_cache_invalidate_all",
+      "_type": "request",
+      "parentId": "fld_internal_cache",
+      "name": "Invalidate Cache (all)",
+      "method": "POST",
+      "url": "{{ _.base_url }}/internal/cache/invalidate",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n  \"scope\": \"all\"\n}"
+      },
+      "authentication": {
+        "type": "bearer",
+        "token": "{{ _.admin_bearer_token }}"
+      },
+      "headers": [
+        {
+          "name": "Content-Type",
+          "value": "application/json"
+        }
+      ]
+    },
+    {
+      "_id": "req_cache_invalidate_dry_run",
+      "_type": "request",
+      "parentId": "fld_internal_cache",
+      "name": "Invalidate Cache (dry-run)",
+      "method": "POST",
+      "url": "{{ _.base_url }}/internal/cache/invalidate",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n  \"scope\": \"exact\",\n  \"path\": \"/pst/find?areaId=10790\",\n  \"dryRun\": true\n}"
+      },
+      "authentication": {
+        "type": "bearer",
+        "token": "{{ _.admin_bearer_token }}"
+      },
+      "headers": [
+        {
+          "name": "Content-Type",
+          "value": "application/json"
+        }
+      ]
     }
   ]
 }

--- a/openspec/changes/archive/2026-02-11-add-admin-proxy-cache-invalidation/proposal.md
+++ b/openspec/changes/archive/2026-02-11-add-admin-proxy-cache-invalidation/proposal.md
@@ -1,0 +1,27 @@
+# Change: Add Admin Proxy Cache Invalidation
+
+## Why
+
+The upstream API does not provide reliable change indicators (for example ETag or webhook updates), so stale proxy cache entries can persist longer than acceptable. Operations needs a controlled manual mechanism to invalidate proxy cache entries without flushing unrelated Redis data.
+
+## What Changes
+
+- Add a new admin-protected endpoint `POST /internal/cache/invalidate`.
+- Support three invalidation scopes for proxy GET cache keys:
+  - `exact` (default broad by `path`, optional `strict=true` for exact variant)
+  - `prefix`
+  - `all`
+- Support `dryRun` mode to report matches without deleting.
+- Reuse existing `AdminAuthGuard` security and audit context (`adminIdentity`, IP, request ID).
+- Add logging for cache invalidation audit events.
+- Add unit and e2e coverage for success and failure paths.
+
+## Impact
+
+- Affected specs: `backend-platform`
+- Affected code:
+  - `src/cache/*` (new cache admin service/controller)
+  - module wiring for internal endpoint exposure
+  - `test/proxy.e2e-spec.ts`
+  - `README.md`
+  - `doc/insomnia/*.json`

--- a/openspec/changes/archive/2026-02-11-add-admin-proxy-cache-invalidation/specs/backend-platform/spec.md
+++ b/openspec/changes/archive/2026-02-11-add-admin-proxy-cache-invalidation/specs/backend-platform/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Admin-authenticated proxy cache invalidation
+
+The backend platform SHALL provide an internal admin endpoint to invalidate proxy GET cache entries manually.
+
+#### Scenario: Unauthorized cache invalidation request
+
+- **WHEN** a request to `POST /internal/cache/invalidate` is missing a valid `Authorization: Bearer` token
+- **THEN** the service responds with HTTP 401 and no cache keys are deleted
+
+#### Scenario: Exact invalidation (default broad)
+
+- **WHEN** an admin submits `scope=exact` with a `path` and without `strict=true`
+- **THEN** the service invalidates all cache variants for that exact path/query target and returns counts for `matched` and `deleted`
+
+#### Scenario: Exact invalidation (strict variant)
+
+- **WHEN** an admin submits `scope=exact`, `strict=true`, and variant-defining headers
+- **THEN** the service invalidates only the single exact cache key variant for that request shape
+
+#### Scenario: Prefix invalidation
+
+- **WHEN** an admin submits `scope=prefix` with a `pathPrefix`
+- **THEN** the service invalidates matching `proxy:GET:` cache keys under that prefix only
+
+#### Scenario: Global proxy cache invalidation
+
+- **WHEN** an admin submits `scope=all`
+- **THEN** the service invalidates all `proxy:GET:*` keys and leaves non-proxy namespaces untouched
+
+#### Scenario: Dry-run invalidation
+
+- **WHEN** an admin submits `dryRun=true`
+- **THEN** the service reports matching key count and performs no deletions
+
+#### Scenario: Redis unavailable during invalidation
+
+- **WHEN** the cache backend client is unavailable
+- **THEN** the service responds with HTTP 503 and reports invalidation backend unavailable
+
+### Requirement: Safe Redis key scanning for invalidation
+
+The backend platform SHALL use non-blocking Redis key scanning for admin cache invalidation operations.
+
+#### Scenario: Invalidation executes in production-safe pattern
+
+- **WHEN** cache invalidation is executed
+- **THEN** the service uses Redis `SCAN` with batched deletion and does not use Redis `KEYS`

--- a/openspec/changes/archive/2026-02-11-add-admin-proxy-cache-invalidation/tasks.md
+++ b/openspec/changes/archive/2026-02-11-add-admin-proxy-cache-invalidation/tasks.md
@@ -1,0 +1,28 @@
+## 1. Implementation
+
+- [x] 1.1 Add cache admin invalidation endpoint `POST /internal/cache/invalidate` protected by `AdminAuthGuard`
+- [x] 1.2 Implement cache invalidation service for scopes `exact`, `prefix`, and `all`
+- [x] 1.3 Implement `exact` hybrid behavior: broad by default, strict single-key invalidation when `strict=true`
+- [x] 1.4 Implement `dryRun` behavior that reports `matched` without deleting keys
+- [x] 1.5 Ensure invalidation only targets `proxy:GET:*` keys and never touches API key registry keys
+- [x] 1.6 Use Redis `SCAN` + batch `DEL` (no `KEYS`) for safe production operation
+- [x] 1.7 Add structured admin audit logging for invalidation requests and outcomes
+- [x] 1.8 Wire endpoint into existing modules without breaking current API key/proxy auth flow
+
+## 2. Tests
+
+- [x] 2.1 Add unit tests for cache invalidation service (`exact`, `prefix`, `all`, `dryRun`, Redis unavailable)
+- [x] 2.2 Add controller tests for payload validation and guard-protected behavior
+- [x] 2.3 Extend e2e tests to verify `MISS -> HIT -> invalidate -> MISS` flow
+- [x] 2.4 Add e2e coverage for unauthorized admin calls and `dryRun` behavior
+
+## 3. Documentation
+
+- [x] 3.1 Update `README.md` with endpoint contract and examples
+- [x] 3.2 Add/extend Insomnia collection for cache invalidation admin endpoint
+
+## 4. Validation
+
+- [x] 4.1 Run `npm test`
+- [x] 4.2 Run `npm run test:e2e`
+- [x] 4.3 Run `openspec validate add-admin-proxy-cache-invalidation --strict --no-interactive`

--- a/openspec/specs/backend-platform/spec.md
+++ b/openspec/specs/backend-platform/spec.md
@@ -340,3 +340,51 @@ The backend platform SHALL never forward `x-api-key` to the upstream API.
 - **WHEN** a client sends `x-api-key` with a proxied request
 - **THEN** the proxy strips `x-api-key` before forwarding headers upstream
 
+### Requirement: Admin-authenticated proxy cache invalidation
+
+The backend platform SHALL provide an internal admin endpoint to invalidate proxy GET cache entries manually.
+
+#### Scenario: Unauthorized cache invalidation request
+
+- **WHEN** a request to `POST /internal/cache/invalidate` is missing a valid `Authorization: Bearer` token
+- **THEN** the service responds with HTTP 401 and no cache keys are deleted
+
+#### Scenario: Exact invalidation (default broad)
+
+- **WHEN** an admin submits `scope=exact` with a `path` and without `strict=true`
+- **THEN** the service invalidates all cache variants for that exact path/query target and returns counts for `matched` and `deleted`
+
+#### Scenario: Exact invalidation (strict variant)
+
+- **WHEN** an admin submits `scope=exact`, `strict=true`, and variant-defining headers
+- **THEN** the service invalidates only the single exact cache key variant for that request shape
+
+#### Scenario: Prefix invalidation
+
+- **WHEN** an admin submits `scope=prefix` with a `pathPrefix`
+- **THEN** the service invalidates matching `proxy:GET:` cache keys under that prefix only
+
+#### Scenario: Global proxy cache invalidation
+
+- **WHEN** an admin submits `scope=all`
+- **THEN** the service invalidates all `proxy:GET:*` keys and leaves non-proxy namespaces untouched
+
+#### Scenario: Dry-run invalidation
+
+- **WHEN** an admin submits `dryRun=true`
+- **THEN** the service reports matching key count and performs no deletions
+
+#### Scenario: Redis unavailable during invalidation
+
+- **WHEN** the cache backend client is unavailable
+- **THEN** the service responds with HTTP 503 and reports invalidation backend unavailable
+
+### Requirement: Safe Redis key scanning for invalidation
+
+The backend platform SHALL use non-blocking Redis key scanning for admin cache invalidation operations.
+
+#### Scenario: Invalidation executes in production-safe pattern
+
+- **WHEN** cache invalidation is executed
+- **THEN** the service uses Redis `SCAN` with batched deletion and does not use Redis `KEYS`
+

--- a/src/api-keys/api-keys.module.ts
+++ b/src/api-keys/api-keys.module.ts
@@ -1,6 +1,8 @@
 import { Module } from '@nestjs/common';
 
 import { CacheModule } from '../cache/cache.module';
+import { CacheAdminController } from '../cache/cache-admin.controller';
+import { CacheAdminService } from '../cache/cache-admin.service';
 import { AdminAuthGuard } from './admin-auth.guard';
 import { ApiKeysService } from './api-keys.service';
 import { ApiKeysAdminController } from './api-keys-admin.controller';
@@ -8,8 +10,8 @@ import { ProxyAccessGuard } from './proxy-access.guard';
 
 @Module({
   imports: [CacheModule],
-  controllers: [ApiKeysAdminController],
-  providers: [ApiKeysService, ProxyAccessGuard, AdminAuthGuard],
+  controllers: [ApiKeysAdminController, CacheAdminController],
+  providers: [ApiKeysService, ProxyAccessGuard, AdminAuthGuard, CacheAdminService],
   exports: [ApiKeysService, ProxyAccessGuard],
 })
 export class ApiKeysModule {}

--- a/src/cache/cache-admin.controller.spec.ts
+++ b/src/cache/cache-admin.controller.spec.ts
@@ -1,0 +1,101 @@
+import { CanActivate } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { AdminAuthGuard } from '../api-keys/admin-auth.guard';
+import { CacheAdminController } from './cache-admin.controller';
+import { CacheAdminService } from './cache-admin.service';
+
+describe('CacheAdminController', () => {
+  let controller: CacheAdminController;
+  let cacheAdminService: { invalidate: jest.Mock };
+
+  beforeEach(async () => {
+    cacheAdminService = {
+      invalidate: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CacheAdminController],
+      providers: [
+        {
+          provide: CacheAdminService,
+          useValue: cacheAdminService,
+        },
+      ],
+    })
+      .overrideGuard(AdminAuthGuard)
+      .useValue({ canActivate: () => true } as CanActivate)
+      .compile();
+
+    controller = module.get<CacheAdminController>(CacheAdminController);
+  });
+
+  it('returns successful invalidation response', async () => {
+    cacheAdminService.invalidate.mockResolvedValueOnce({
+      scope: 'exact',
+      dryRun: false,
+      matched: 2,
+      deleted: 2,
+    });
+
+    await expect(
+      controller.invalidate(
+        {
+          headers: {},
+          ip: '127.0.0.1',
+          adminIdentity: 'token:abcd',
+        } as never,
+        {
+          scope: 'exact',
+          path: '/pst/find?areaId=10790',
+        },
+      ),
+    ).resolves.toEqual({
+      ok: true,
+      scope: 'exact',
+      dryRun: false,
+      matched: 2,
+      deleted: 2,
+    });
+  });
+
+  it('rejects invalid scope values with 400', async () => {
+    await expect(
+      controller.invalidate(
+        {
+          headers: {},
+          ip: '127.0.0.1',
+          adminIdentity: 'token:abcd',
+        } as never,
+        {
+          scope: 'invalid',
+        },
+      ),
+    ).rejects.toMatchObject({
+      status: 400,
+    });
+    expect(cacheAdminService.invalidate).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid header payload values with 400', async () => {
+    await expect(
+      controller.invalidate(
+        {
+          headers: {},
+          ip: '127.0.0.1',
+          adminIdentity: 'token:abcd',
+        } as never,
+        {
+          scope: 'exact',
+          path: '/pst/find?areaId=10790',
+          headers: {
+            acceptLanguage: 123,
+          },
+        },
+      ),
+    ).rejects.toMatchObject({
+      status: 400,
+    });
+    expect(cacheAdminService.invalidate).not.toHaveBeenCalled();
+  });
+});

--- a/src/cache/cache-admin.controller.ts
+++ b/src/cache/cache-admin.controller.ts
@@ -1,0 +1,331 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Logger,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import type { FastifyRequest } from 'fastify';
+
+import { AdminAuthGuard } from '../api-keys/admin-auth.guard';
+import { hashKeyForLogging } from '../utils/hash';
+import {
+  CacheAdminService,
+  InvalidateProxyCacheInput,
+  InvalidateProxyCacheResult,
+} from './cache-admin.service';
+
+type InvalidateBody = {
+  scope?: unknown;
+  dryRun?: unknown;
+  path?: unknown;
+  strict?: unknown;
+  headers?: unknown;
+  pathPrefix?: unknown;
+};
+
+type StrictHeadersBody = {
+  accept?: unknown;
+  acceptLanguage?: unknown;
+  apiKey?: unknown;
+};
+
+type RequestWithAdminIdentity = FastifyRequest & {
+  adminIdentity?: string;
+};
+
+@Controller('internal/cache')
+@UseGuards(AdminAuthGuard)
+export class CacheAdminController {
+  private readonly logger = new Logger(CacheAdminController.name);
+
+  constructor(private readonly cacheAdminService: CacheAdminService) {}
+
+  @Post('invalidate')
+  async invalidate(
+    @Req() request: RequestWithAdminIdentity,
+    @Body() body: InvalidateBody,
+  ): Promise<InvalidateProxyCacheResult & { ok: true }> {
+    try {
+      const input = this.parseBody(body);
+      const result = await this.cacheAdminService.invalidate(input);
+      this.audit(request, { ...result, ...this.buildAuditTargetFromInput(input) }, 'ok');
+      return {
+        ok: true,
+        ...result,
+      };
+    } catch (error) {
+      this.audit(
+        request,
+        {
+          scope: this.tryReadScope(body),
+          dryRun: this.readDryRun(body),
+          ...this.buildAuditTargetFromBody(body),
+        },
+        'error',
+        {
+          reason: this.errorReason(error),
+        },
+      );
+      throw error;
+    }
+  }
+
+  private parseBody(body: InvalidateBody): InvalidateProxyCacheInput {
+    const scope = this.parseScope(body?.scope);
+    const dryRun = this.parseOptionalBoolean(body?.dryRun, 'dryRun') ?? false;
+
+    if (scope === 'all') {
+      return { scope, dryRun };
+    }
+
+    if (scope === 'prefix') {
+      const pathPrefix = this.parseRequiredString(body?.pathPrefix, 'pathPrefix');
+      return {
+        scope,
+        pathPrefix,
+        dryRun,
+      };
+    }
+
+    const path = this.parseRequiredString(body?.path, 'path');
+    const strict = this.parseOptionalBoolean(body?.strict, 'strict') ?? false;
+    const headers = this.parseStrictHeaders(body?.headers);
+
+    return {
+      scope,
+      path,
+      strict,
+      headers,
+      dryRun,
+    };
+  }
+
+  private parseScope(value: unknown): 'exact' | 'prefix' | 'all' {
+    if (value === 'exact' || value === 'prefix' || value === 'all') {
+      return value;
+    }
+
+    throw new BadRequestException('scope must be one of: exact, prefix, all');
+  }
+
+  private parseRequiredString(value: unknown, fieldName: string): string {
+    if (typeof value !== 'string') {
+      throw new BadRequestException(`${fieldName} must be a string`);
+    }
+
+    const normalized = value.trim();
+    if (normalized.length === 0) {
+      throw new BadRequestException(`${fieldName} is required`);
+    }
+
+    return normalized;
+  }
+
+  private parseStrictHeaders(value: unknown):
+    | {
+        accept?: string;
+        acceptLanguage?: string;
+        apiKey?: string;
+      }
+    | undefined {
+    if (value === undefined || value === null) {
+      return undefined;
+    }
+
+    if (typeof value !== 'object' || Array.isArray(value)) {
+      throw new BadRequestException('headers must be an object');
+    }
+
+    const payload = value as StrictHeadersBody;
+
+    return {
+      accept: this.parseOptionalString(payload.accept, 'headers.accept'),
+      acceptLanguage: this.parseOptionalString(payload.acceptLanguage, 'headers.acceptLanguage'),
+      apiKey: this.parseOptionalString(payload.apiKey, 'headers.apiKey'),
+    };
+  }
+
+  private parseOptionalString(value: unknown, fieldName: string): string | undefined {
+    if (value === undefined || value === null) {
+      return undefined;
+    }
+
+    if (typeof value !== 'string') {
+      throw new BadRequestException(`${fieldName} must be a string`);
+    }
+
+    const normalized = value.trim();
+    return normalized.length > 0 ? normalized : undefined;
+  }
+
+  private parseOptionalBoolean(value: unknown, fieldName: string): boolean | undefined {
+    if (value === undefined || value === null) {
+      return undefined;
+    }
+
+    if (typeof value !== 'boolean') {
+      throw new BadRequestException(`${fieldName} must be a boolean`);
+    }
+
+    return value;
+  }
+
+  private audit(
+    request: RequestWithAdminIdentity,
+    input: {
+      scope?: string;
+      dryRun?: boolean;
+      matched?: number;
+      deleted?: number;
+      path?: string;
+      pathPrefix?: string;
+      strict?: boolean;
+      headerVariantFingerprint?: string;
+    },
+    result: 'ok' | 'error',
+    details?: Record<string, unknown>,
+  ): void {
+    const requestIdHeader = request.headers['x-request-id'];
+    const requestId = Array.isArray(requestIdHeader) ? requestIdHeader[0] : requestIdHeader;
+
+    const payload = {
+      event: 'admin_cache_invalidation_audit',
+      action: 'invalidate',
+      scope: input.scope ?? 'unknown',
+      dryRun: input.dryRun ?? false,
+      matched: input.matched ?? null,
+      deleted: input.deleted ?? null,
+      path: input.path ?? null,
+      pathPrefix: input.pathPrefix ?? null,
+      strict: input.strict ?? null,
+      headerVariantFingerprint: input.headerVariantFingerprint ?? null,
+      result,
+      adminIdentity: request.adminIdentity ?? 'unknown',
+      ip: request.ip ?? 'unknown',
+      requestId: requestId ?? null,
+      ...details,
+    };
+
+    if (result === 'error') {
+      this.logger.warn(JSON.stringify(payload));
+      return;
+    }
+
+    this.logger.log(JSON.stringify(payload));
+  }
+
+  private tryReadScope(body: InvalidateBody | undefined): string | undefined {
+    return typeof body?.scope === 'string' ? body.scope : undefined;
+  }
+
+  private readDryRun(body: InvalidateBody | undefined): boolean {
+    return body?.dryRun === true;
+  }
+
+  private buildAuditTargetFromInput(input: InvalidateProxyCacheInput): {
+    path?: string;
+    pathPrefix?: string;
+    strict?: boolean;
+    headerVariantFingerprint?: string;
+  } {
+    if (input.scope === 'exact') {
+      return {
+        path: input.path,
+        strict: input.strict ?? false,
+        headerVariantFingerprint: this.computeHeaderVariantFingerprint(input.headers),
+      };
+    }
+
+    if (input.scope === 'prefix') {
+      return {
+        pathPrefix: input.pathPrefix,
+      };
+    }
+
+    return {};
+  }
+
+  private buildAuditTargetFromBody(body: InvalidateBody | undefined): {
+    path?: string;
+    pathPrefix?: string;
+    strict?: boolean;
+    headerVariantFingerprint?: string;
+  } {
+    const path = typeof body?.path === 'string' ? body.path.trim() : undefined;
+    const pathPrefix = typeof body?.pathPrefix === 'string' ? body.pathPrefix.trim() : undefined;
+    const strict = typeof body?.strict === 'boolean' ? body.strict : undefined;
+    const headerVariantFingerprint = this.computeHeaderVariantFingerprint(
+      this.readStrictHeaders(body),
+    );
+
+    return {
+      path: path && path.length > 0 ? path : undefined,
+      pathPrefix: pathPrefix && pathPrefix.length > 0 ? pathPrefix : undefined,
+      strict,
+      headerVariantFingerprint,
+    };
+  }
+
+  private readStrictHeaders(
+    body: InvalidateBody | undefined,
+  ): { accept?: string; acceptLanguage?: string; apiKey?: string } | undefined {
+    if (
+      !body ||
+      typeof body.headers !== 'object' ||
+      body.headers === null ||
+      Array.isArray(body.headers)
+    ) {
+      return undefined;
+    }
+
+    const payload = body.headers as StrictHeadersBody;
+    const accept = typeof payload.accept === 'string' ? payload.accept.trim() : undefined;
+    const acceptLanguage =
+      typeof payload.acceptLanguage === 'string' ? payload.acceptLanguage.trim() : undefined;
+    const apiKey = typeof payload.apiKey === 'string' ? payload.apiKey.trim() : undefined;
+
+    return {
+      accept: accept && accept.length > 0 ? accept : undefined,
+      acceptLanguage: acceptLanguage && acceptLanguage.length > 0 ? acceptLanguage : undefined,
+      apiKey: apiKey && apiKey.length > 0 ? apiKey : undefined,
+    };
+  }
+
+  private computeHeaderVariantFingerprint(
+    headers:
+      | {
+          accept?: string;
+          acceptLanguage?: string;
+          apiKey?: string;
+        }
+      | undefined,
+  ): string | undefined {
+    if (!headers) {
+      return undefined;
+    }
+
+    const hasAnyHeader = Boolean(headers.accept || headers.acceptLanguage || headers.apiKey);
+    if (!hasAnyHeader) {
+      return undefined;
+    }
+
+    return hashKeyForLogging(
+      JSON.stringify({
+        accept: headers.accept ?? '',
+        acceptLanguage: headers.acceptLanguage ?? '',
+        apiKey: headers.apiKey ?? '',
+      }),
+    );
+  }
+
+  private errorReason(error: unknown): string {
+    if (error instanceof Error) {
+      return error.name;
+    }
+
+    return 'UnknownError';
+  }
+}

--- a/src/cache/cache-admin.service.spec.ts
+++ b/src/cache/cache-admin.service.spec.ts
@@ -1,0 +1,271 @@
+import { ServiceUnavailableException } from '@nestjs/common';
+
+import { buildProxyCacheKey } from '../proxy/proxy-cache';
+import { CacheService } from './cache.service';
+import { CacheAdminService } from './cache-admin.service';
+
+type MockRedisClient = {
+  scan: jest.Mock;
+  del: jest.Mock;
+};
+
+describe('CacheAdminService', () => {
+  let service: CacheAdminService;
+  let redisKeys: Set<string>;
+  let redisClient: MockRedisClient;
+  let cacheService: { getStoreClient: jest.Mock };
+
+  const toRegex = (pattern: string): RegExp => {
+    let regex = '^';
+
+    for (let index = 0; index < pattern.length; index += 1) {
+      const char = pattern[index];
+      if (!char) {
+        continue;
+      }
+
+      if (char === '\\') {
+        const next = pattern[index + 1];
+        if (next) {
+          regex += next.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&');
+          index += 1;
+        } else {
+          regex += '\\\\';
+        }
+        continue;
+      }
+
+      if (char === '*') {
+        regex += '.*';
+        continue;
+      }
+
+      if (char === '?') {
+        regex += '.';
+        continue;
+      }
+
+      regex += char.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&');
+    }
+
+    regex += '$';
+    return new RegExp(regex);
+  };
+
+  beforeEach(() => {
+    redisKeys = new Set<string>();
+
+    redisClient = {
+      scan: jest.fn(async (_cursor: string, options: { MATCH: string }) => {
+        const matcher = toRegex(options.MATCH);
+        const keys = [...redisKeys].filter((key) => matcher.test(key));
+        return ['0', keys];
+      }),
+      del: jest.fn(async (...keys: string[]) => {
+        let deleted = 0;
+        keys.forEach((key) => {
+          if (redisKeys.delete(key)) {
+            deleted += 1;
+          }
+        });
+        return deleted;
+      }),
+    };
+
+    cacheService = {
+      getStoreClient: jest.fn().mockReturnValue(redisClient),
+    };
+
+    service = new CacheAdminService(cacheService as unknown as CacheService);
+  });
+
+  it('invalidates all variants for exact path by default', async () => {
+    redisKeys.add('proxy:GET:/pst/find?areaId=10790:variant-a');
+    redisKeys.add('proxy:GET:/pst/find?areaId=10790:variant-b');
+    redisKeys.add('proxy:GET:/pst/find?areaId=42:variant-c');
+
+    await expect(
+      service.invalidate({
+        scope: 'exact',
+        path: '/pst/find?areaId=10790',
+      }),
+    ).resolves.toEqual({
+      scope: 'exact',
+      dryRun: false,
+      matched: 2,
+      deleted: 2,
+    });
+
+    expect(redisKeys.has('proxy:GET:/pst/find?areaId=42:variant-c')).toBe(true);
+  });
+
+  it('invalidates only strict cache key when strict=true', async () => {
+    const targetKey = buildProxyCacheKey('GET', '/pst/find?areaId=10790', {
+      accept: '*/*',
+      'accept-language': 'de-DE',
+      api_key: 'client-A',
+    });
+    const otherVariant = buildProxyCacheKey('GET', '/pst/find?areaId=10790', {
+      accept: '*/*',
+      'accept-language': 'en-US',
+      api_key: 'client-A',
+    });
+
+    redisKeys.add(targetKey);
+    redisKeys.add(otherVariant);
+
+    await expect(
+      service.invalidate({
+        scope: 'exact',
+        path: '/pst/find?areaId=10790',
+        strict: true,
+        headers: {
+          accept: '*/*',
+          acceptLanguage: 'de-DE',
+          apiKey: 'client-A',
+        },
+      }),
+    ).resolves.toEqual({
+      scope: 'exact',
+      dryRun: false,
+      matched: 1,
+      deleted: 1,
+    });
+
+    expect(redisKeys.has(targetKey)).toBe(false);
+    expect(redisKeys.has(otherVariant)).toBe(true);
+  });
+
+  it('returns matched=0 for strict dryRun when key does not exist', async () => {
+    await expect(
+      service.invalidate({
+        scope: 'exact',
+        path: '/pst/find?areaId=99999',
+        strict: true,
+        dryRun: true,
+        headers: {
+          accept: '*/*',
+          acceptLanguage: 'de-DE',
+          apiKey: 'missing-client',
+        },
+      }),
+    ).resolves.toEqual({
+      scope: 'exact',
+      dryRun: true,
+      matched: 0,
+      deleted: 0,
+    });
+  });
+
+  it('returns matched=0 for strict delete when key does not exist', async () => {
+    await expect(
+      service.invalidate({
+        scope: 'exact',
+        path: '/pst/find?areaId=99999',
+        strict: true,
+        headers: {
+          accept: '*/*',
+          acceptLanguage: 'de-DE',
+          apiKey: 'missing-client',
+        },
+      }),
+    ).resolves.toEqual({
+      scope: 'exact',
+      dryRun: false,
+      matched: 0,
+      deleted: 0,
+    });
+  });
+
+  it('invalidates only matching prefix keys', async () => {
+    redisKeys.add('proxy:GET:/pst/find?areaId=10790:variant-a');
+    redisKeys.add('proxy:GET:/pst/find/details?areaId=10790:variant-b');
+    redisKeys.add('proxy:GET:/other/path?x=1:variant-c');
+
+    await expect(
+      service.invalidate({
+        scope: 'prefix',
+        pathPrefix: '/pst/find',
+      }),
+    ).resolves.toEqual({
+      scope: 'prefix',
+      dryRun: false,
+      matched: 2,
+      deleted: 2,
+    });
+
+    expect(redisKeys.has('proxy:GET:/other/path?x=1:variant-c')).toBe(true);
+  });
+
+  it('invalidates all proxy GET keys only', async () => {
+    redisKeys.add('proxy:GET:/a:1');
+    redisKeys.add('proxy:GET:/b:2');
+    redisKeys.add('api-keys:key:123');
+
+    await expect(
+      service.invalidate({
+        scope: 'all',
+      }),
+    ).resolves.toEqual({
+      scope: 'all',
+      dryRun: false,
+      matched: 2,
+      deleted: 2,
+    });
+
+    expect(redisKeys.has('api-keys:key:123')).toBe(true);
+  });
+
+  it('supports dryRun without deletion', async () => {
+    redisKeys.add('proxy:GET:/pst/find?areaId=10790:variant-a');
+
+    await expect(
+      service.invalidate({
+        scope: 'exact',
+        path: '/pst/find?areaId=10790',
+        dryRun: true,
+      }),
+    ).resolves.toEqual({
+      scope: 'exact',
+      dryRun: true,
+      matched: 1,
+      deleted: 0,
+    });
+
+    expect(redisKeys.has('proxy:GET:/pst/find?areaId=10790:variant-a')).toBe(true);
+    expect(redisClient.del).not.toHaveBeenCalled();
+  });
+
+  it('throws 503 when redis client is unavailable', async () => {
+    cacheService.getStoreClient.mockReturnValueOnce(null);
+
+    await expect(
+      service.invalidate({
+        scope: 'all',
+      }),
+    ).rejects.toBeInstanceOf(ServiceUnavailableException);
+  });
+
+  it('deletes keys in multi-key batches instead of per-key deletes', async () => {
+    for (let index = 0; index < 250; index += 1) {
+      redisKeys.add(`proxy:GET:/bulk/${index}:variant`);
+    }
+
+    await expect(
+      service.invalidate({
+        scope: 'prefix',
+        pathPrefix: '/bulk',
+      }),
+    ).resolves.toEqual({
+      scope: 'prefix',
+      dryRun: false,
+      matched: 250,
+      deleted: 250,
+    });
+
+    expect(redisClient.del).toHaveBeenCalledTimes(3);
+    expect(redisClient.del.mock.calls[0]?.length).toBe(100);
+    expect(redisClient.del.mock.calls[1]?.length).toBe(100);
+    expect(redisClient.del.mock.calls[2]?.length).toBe(50);
+  });
+});

--- a/src/cache/cache-admin.service.ts
+++ b/src/cache/cache-admin.service.ts
@@ -1,0 +1,336 @@
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+
+import { buildProxyCacheKey } from '../proxy/proxy-cache';
+import { CacheService } from './cache.service';
+
+const PROXY_GET_CACHE_KEY_PREFIX = 'proxy:GET:';
+const SCAN_BATCH_SIZE = 200;
+const DELETE_BATCH_SIZE = 100;
+
+export type CacheInvalidationScope = 'exact' | 'prefix' | 'all';
+
+export type StrictCacheKeyHeaders = {
+  accept?: string;
+  acceptLanguage?: string;
+  apiKey?: string;
+};
+
+export type InvalidateExactInput = {
+  scope: 'exact';
+  path: string;
+  strict?: boolean;
+  headers?: StrictCacheKeyHeaders;
+  dryRun?: boolean;
+};
+
+export type InvalidatePrefixInput = {
+  scope: 'prefix';
+  pathPrefix: string;
+  dryRun?: boolean;
+};
+
+export type InvalidateAllInput = {
+  scope: 'all';
+  dryRun?: boolean;
+};
+
+export type InvalidateProxyCacheInput =
+  | InvalidateExactInput
+  | InvalidatePrefixInput
+  | InvalidateAllInput;
+
+export type InvalidateProxyCacheResult = {
+  scope: CacheInvalidationScope;
+  dryRun: boolean;
+  matched: number;
+  deleted: number;
+};
+
+type RedisScanResponse = [string, string[]] | { cursor: number | string; keys: string[] };
+
+type RedisClient = {
+  scan: (
+    cursor: number | string,
+    options: { MATCH: string; COUNT: number },
+  ) => Promise<RedisScanResponse>;
+  del: (...keys: string[]) => Promise<number>;
+  exists?: (...keys: string[]) => Promise<number>;
+};
+
+@Injectable()
+export class CacheAdminService {
+  private readonly logger = new Logger(CacheAdminService.name);
+
+  constructor(private readonly cacheService: CacheService) {}
+
+  async invalidate(input: InvalidateProxyCacheInput): Promise<InvalidateProxyCacheResult> {
+    const dryRun = input.dryRun ?? false;
+
+    if (input.scope === 'all') {
+      return this.invalidateByPattern(input.scope, `${PROXY_GET_CACHE_KEY_PREFIX}*`, dryRun);
+    }
+
+    if (input.scope === 'prefix') {
+      const normalizedPrefix = this.normalizePathPrefix(input.pathPrefix);
+      const escapedPrefix = this.escapeRedisGlob(normalizedPrefix);
+      return this.invalidateByPattern(
+        input.scope,
+        `${PROXY_GET_CACHE_KEY_PREFIX}${escapedPrefix}*`,
+        dryRun,
+      );
+    }
+
+    const normalizedPath = this.normalizePathWithOptionalQuery(input.path);
+    if (input.strict) {
+      const headers: Record<string, string> = {};
+      const accept = this.normalizeHeaderValue(input.headers?.accept);
+      const acceptLanguage = this.normalizeHeaderValue(input.headers?.acceptLanguage);
+      const apiKey = this.normalizeApiKey(input.headers?.apiKey);
+      if (accept) {
+        headers.accept = accept;
+      }
+      if (acceptLanguage) {
+        headers['accept-language'] = acceptLanguage;
+      }
+      if (apiKey) {
+        headers.api_key = apiKey;
+      }
+      const key = buildProxyCacheKey('GET', normalizedPath, {
+        ...headers,
+      });
+      return this.invalidateStrictKey(input.scope, key, dryRun);
+    }
+
+    const escapedPath = this.escapeRedisGlob(normalizedPath);
+    return this.invalidateByPattern(
+      input.scope,
+      `${PROXY_GET_CACHE_KEY_PREFIX}${escapedPath}:*`,
+      dryRun,
+    );
+  }
+
+  private async invalidateByPattern(
+    scope: CacheInvalidationScope,
+    pattern: string,
+    dryRun: boolean,
+  ): Promise<InvalidateProxyCacheResult> {
+    const redis = this.getRedisClient();
+    return this.scanAndInvalidateByPattern(redis, scope, pattern, dryRun);
+  }
+
+  private async scanAndInvalidateByPattern(
+    redis: RedisClient,
+    scope: CacheInvalidationScope,
+    pattern: string,
+    dryRun: boolean,
+  ): Promise<InvalidateProxyCacheResult> {
+    let cursor = '0';
+    let matched = 0;
+    let deleted = 0;
+
+    do {
+      const response = await redis.scan(cursor, {
+        MATCH: pattern,
+        COUNT: SCAN_BATCH_SIZE,
+      });
+      const { nextCursor, batchKeys } = this.parseScanResponse(response);
+      matched += batchKeys.length;
+      if (!dryRun && batchKeys.length > 0) {
+        deleted += await this.deleteInBatches(redis, batchKeys);
+      }
+      cursor = nextCursor;
+    } while (cursor !== '0');
+
+    return {
+      scope,
+      dryRun,
+      matched,
+      deleted,
+    };
+  }
+
+  private parseScanResponse(response: RedisScanResponse): {
+    nextCursor: string;
+    batchKeys: string[];
+  } {
+    if (Array.isArray(response)) {
+      const [nextCursor, batchKeys] = response;
+      return { nextCursor: String(nextCursor), batchKeys };
+    }
+
+    return {
+      nextCursor: String(response.cursor),
+      batchKeys: response.keys,
+    };
+  }
+
+  private async invalidateKeys(
+    scope: CacheInvalidationScope,
+    keys: string[],
+    dryRun: boolean,
+  ): Promise<InvalidateProxyCacheResult> {
+    if (keys.length === 0) {
+      return {
+        scope,
+        dryRun,
+        matched: 0,
+        deleted: 0,
+      };
+    }
+
+    if (dryRun) {
+      return {
+        scope,
+        dryRun,
+        matched: keys.length,
+        deleted: 0,
+      };
+    }
+
+    const redis = this.getRedisClient();
+    const deleted = await this.deleteInBatches(redis, keys);
+
+    return {
+      scope,
+      dryRun,
+      matched: keys.length,
+      deleted,
+    };
+  }
+
+  private async invalidateStrictKey(
+    scope: CacheInvalidationScope,
+    key: string,
+    dryRun: boolean,
+  ): Promise<InvalidateProxyCacheResult> {
+    const redis = this.getRedisClient();
+    if (dryRun) {
+      const exists = await this.keyExists(redis, key);
+      return {
+        scope,
+        dryRun: true,
+        matched: exists ? 1 : 0,
+        deleted: 0,
+      };
+    }
+
+    const deleted = await redis.del(key);
+    return {
+      scope,
+      dryRun: false,
+      matched: deleted > 0 ? 1 : 0,
+      deleted,
+    };
+  }
+
+  private async keyExists(redis: RedisClient, key: string): Promise<boolean> {
+    if (typeof redis.exists === 'function') {
+      const result = await redis.exists(key);
+      return result > 0;
+    }
+
+    const escapedKey = this.escapeRedisGlob(key);
+    let cursor = '0';
+
+    do {
+      const response = await redis.scan(cursor, {
+        MATCH: escapedKey,
+        COUNT: 1,
+      });
+      const { nextCursor, batchKeys } = this.parseScanResponse(response);
+      if (batchKeys.includes(key)) {
+        return true;
+      }
+      cursor = nextCursor;
+    } while (cursor !== '0');
+
+    return false;
+  }
+
+  private async deleteInBatches(redis: RedisClient, keys: string[]): Promise<number> {
+    let deleted = 0;
+
+    for (let index = 0; index < keys.length; index += DELETE_BATCH_SIZE) {
+      const batch = keys.slice(index, index + DELETE_BATCH_SIZE);
+      deleted += await redis.del(...batch);
+    }
+
+    return deleted;
+  }
+
+  private getRedisClient(): RedisClient {
+    const client = this.cacheService.getStoreClient<RedisClient>();
+    if (!client || typeof client.scan !== 'function' || typeof client.del !== 'function') {
+      this.logger.error('Redis client unavailable for cache invalidation');
+      throw new ServiceUnavailableException('Cache invalidation backend unavailable');
+    }
+
+    return client;
+  }
+
+  private normalizePathWithOptionalQuery(value: string): string {
+    const trimmed = value.trim();
+    const queryIndex = trimmed.indexOf('?');
+    if (queryIndex < 0) {
+      return this.normalizePathPart(trimmed);
+    }
+
+    const rawPathPart = trimmed.slice(0, queryIndex);
+    const rawQuery = trimmed.slice(queryIndex + 1);
+    const normalizedPath = this.normalizePathPart(rawPathPart);
+
+    if (rawQuery.trim().length === 0) {
+      return normalizedPath;
+    }
+
+    return `${normalizedPath}?${rawQuery}`;
+  }
+
+  private normalizePathPrefix(value: string): string {
+    const trimmed = value.trim();
+    if (trimmed.includes('?')) {
+      throw new BadRequestException('pathPrefix must not contain query parameters');
+    }
+
+    return this.normalizePathPart(trimmed);
+  }
+
+  private normalizePathPart(value: string): string {
+    if (value.includes('://')) {
+      throw new BadRequestException('path must not be an absolute URL');
+    }
+
+    const withLeadingSlash = value.startsWith('/') ? value : `/${value}`;
+    const collapsed = withLeadingSlash.replace(/\/{2,}/g, '/');
+    const normalized = collapsed.replace(/\/+$/g, '');
+
+    return normalized.length === 0 ? '/' : normalized;
+  }
+
+  private normalizeHeaderValue(value: string | undefined): string | undefined {
+    const trimmed = value?.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+
+    return trimmed;
+  }
+
+  private normalizeApiKey(value: string | undefined): string | undefined {
+    const trimmed = value?.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+
+    return trimmed;
+  }
+
+  private escapeRedisGlob(value: string): string {
+    return value.replace(/([\\*?[\]])/g, '\\$1');
+  }
+}


### PR DESCRIPTION
Diese Änderung führt eine admin-geschützte manuelle Cache-Invalidierung für den Proxy-GET-Cache ein.  
Damit können stale Einträge gezielt bereinigt werden, auch wenn Upstream keine zuverlässigen Update-Signale (z. B. ETag) liefert.

## Was wurde umgesetzt
- neuer Endpoint `POST /internal/cache/invalidate` (geschützt über `AdminAuthGuard`)
- Invalidation-Scopes:
  - `exact` (standardmäßig breit für denselben Path+Query)
  - `exact` mit `strict=true` (exakte Variante anhand Cache-Key-relevanter Header)
  - `prefix`
  - `all`
- `dryRun`-Modus für Vorschau ohne Löschung
- Redis-schonende Umsetzung über `SCAN` + batch `DEL` (kein `KEYS`)
- Löschung ausschließlich im Namespace `proxy:GET:*` (keine API-Key-Daten betroffen)
- strukturierte Audit-Logs für Invalidation-Aktionen
- Doku und Insomnia-Collection erweitert

### Tests
- Unit-Tests für Service und Controller ergänzt
- E2E-Tests erweitert (`MISS -> HIT -> invalidate -> MISS`, `dryRun`, Unauthorized)
- `npm run lint`, `npm test`, `npm run test:e2e` erfolgreich

### OpenSpec
- OpenSpec-Change `2026-02-11-add-admin-proxy-cache-invalidation` validiert und archiviert
- Spezifikation `backend-platform` aktualisiert

SBB-193